### PR TITLE
Sprint2 flores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,15 @@ pack: ## Genera paquete reproducible básico con out/ y docs/
 	@echo "[pack] paquete: $(DIST_DIR)/$(APP_NAME)-$(RELEASE).tar.gz"
 
 clean: ## Limpieza segura de out/ y dist/
-	@rm -rf $(OUT_DIR) $(DIST_DIR)
+	@sudo rm -rf $(OUT_DIR) $(DIST_DIR)
 	@echo "[clean] limpieza completada"
 
 help: ## Muestra ayuda de targets
 	@echo "Targets disponibles:"
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) | awk -F':|##' '{printf "  %-10s %s\n", $$1, $$3}'
 
+OBJETIVO ?=google.com
+SERVIDOR ?=8.8.8.8
+.PHONY: run-bash
+run-bash: clean
+	@ sudo TARGET=${OBJETIVO} DNS_SERVER=${SERVIDOR} bash src/dns_check.sh

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -111,6 +111,32 @@ test_dns.bats
 
 1 test, 0 failures
 
+## Procesamiento con Unix toolKit 
+
+### Parseado de salida de los comandos curl y dig con grep, cut , awk, ..
+en dns_check.sh
+se agregan las funciones 
+parseo_grep() 
+dentro grep toma el contenido de dns_check.txt y busca el pattern = ([0-9]{1,3}\.){3} los tres primeros bytes de la direccion IPv4 luego ([0-9]{1,3}){1} para el ultimo byte
+de modo que se tienen las lineas buscadas
+``  if [ -f ${archivo}]; then grep -E PATRON archivo > parseo_grep.txt; fi``
+
+se agrega la funcion parseo_cut
+
+
+se agrega la funcion parseo_awk
+awk PATRON_DE_BUSQUEDA ACCION ARCHIVO
+se busca '/PATRON/' '\tA\t' e imprimir la
+### Guardando los resultados procesados en out/
+añadiendo un direccionamiento para guardarlo en un de archivo de salida
+`` > parseo_grep.txt``
+`` > parseo_cut.txt``
+`` > parseo_awk.txt``
+
+![video]()
+
+
+
 ```
 
 - Todas las tareas fueron probadas en Ubuntu 24.04.

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -21,7 +21,14 @@ parseo_grep(){
         grep -E '([0-9]{1,3}\.){3}([0-9]{1,3}){1}' ${ARCHIVO} > ${OUT_DIR}/parseo_grep.txt;fi
 }
  
+parseo_cut() {
+    echo "parseo con cut"
+    if [ -f "$OUT_DIR/parseo_grep.txt" ]; then
+        sed -n '3,8p' "$OUT_DIR/parseo_grep.txt" | cut -d ' ' -f5 > "$OUT_DIR/parseo_cut.txt"
+    fi
+}
+
 parseo_grep
- 
+parseo_cut
 
 

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 set -e
 set -u
@@ -5,11 +6,22 @@ set -o pipefail
 umask 022
 
 TARGET="${TARGET:-google.com}"
-DNS_SERVER="${DNS_SERVER}"
+DNS_SERVER="${DNS_SERVER:-8.8.8.8}"
 OUT_DIR="out"
 mkdir -v -p "$OUT_DIR"
 
 echo "DNS CHECK ($TARGET con $DNS_SERVER)" > "$OUT_DIR/dns_check.txt"
 dig @"$DNS_SERVER" A "$TARGET" >> "$OUT_DIR/dns_check.txt" 2>&1
 
-echo "DNS check guardado en $OUT_DIR/dns_check.txt"
+ARCHIVO="$OUT_DIR/dns_check.txt"
+
+parseo_grep(){
+    echo "parseando"
+    if [ -f ${ARCHIVO} ]; then 
+        grep -E '([0-9]{1,3}\.){3}([0-9]{1,3}){1}' ${ARCHIVO} > ${OUT_DIR}/parseo_grep.txt;fi
+}
+ 
+parseo_grep
+ 
+
+

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -27,8 +27,13 @@ parseo_cut() {
         sed -n '3,8p' "$OUT_DIR/parseo_grep.txt" | cut -d ' ' -f5 > "$OUT_DIR/parseo_cut.txt"
     fi
 }
-
+parseo_awk() {
+    echo "parseando con awk"
+    if [ -f "$ARCHIVO" ]; then
+        awk '/\tA\t/ {print $5}' "$ARCHIVO" > "$OUT_DIR/parseo_awk.txt"
+    fi
+}
 parseo_grep
 parseo_cut
-
+parseo_awk
 

--- a/src/dns_check.sh
+++ b/src/dns_check.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 set -e
 set -u

--- a/src/http_check.sh
+++ b/src/http_check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TARGET="${TARGET}"
+TARGET="${TARGET:-google.com}"
 OUT_DIR="out"
 mkdir -p "$OUT_DIR"
 


### PR DESCRIPTION
Sprint 2 : Adicion de funciones para parseo usndo pipelines con Unix toolkit

Se agregaron funciones de parseo DNS en dns_check.sh (parseo_grep, parseo_cut, parseo_awk) y se creó el test test_dns.bats para verificar que los archivos de salida se generen correctamente.


Era necesario un parseo confiable de las IPs obtenidas por dig para la práctica, y asegurar que los resultados se guarden correctamente en la carpeta out/.


Se implementaron tres funciones de parseo en dns_check.sh para extraer IPs usando grep, cut y awk.


Se añadió .gitignore para ignorar la carpeta out/ y evitar conflictos con archivos temporales.

 grep:
DNS CHECK (example.com con 8.8.8.8)
; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> @8.8.8.8 A example.com
example.com.		200	IN	A	23.192.228.84
example.com.		200	IN	A	23.192.228.80
example.com.		200	IN	A	23.220.75.232
example.com.		200	IN	A	23.220.75.245
example.com.		200	IN	A	23.215.0.138
example.com.		200	IN	A	23.215.0.136
;; SERVER: 8.8.8.8#53(8.8.8.8) (UDP)


cut  :  
example.com.		200	IN	A	23.192.228.84
example.com.		200	IN	A	23.192.228.80
example.com.		200	IN	A	23.220.75.232
example.com.		200	IN	A	23.220.75.245
example.com.		200	IN	A	23.215.0.138
example.com.		200	IN	A	23.215.0.136


awk:
23.192.228.84
23.192.228.80
23.220.75.232
23.220.75.245
23.215.0.138
23.215.0.136

 Código funcional y probado
 Archivos temporales ignorados en .gitignore
 Documentación actualizada y ejemplos de ejecución incluidos
 