### PR TITLE
Feature/sanchez tests bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 APP_NAME ?= pc1-proy5
 RELEASE  ?= v0.1
 
-OBJETIVO ?=example.com
-SERVIDOR ?=8.8.8.8
+TARGET ?=example.com
+DNS_SERVER ?=8.8.8.8
 
 # Variables internas
 OUT_DIR  := out
@@ -47,8 +47,8 @@ build: ## Prepara artefactos mínimos en out
 
 run: tools build ## Ejecuta flujo principal y deja evidencia en out/
 	@mkdir -p $(OUT_DIR)
-	@sudo TARGET=$(OBJETIVO) DNS_SERVER=$(SERVIDOR) bash src/dns_check.sh
-	@sudo TARGET="$(OBJETIVO)" bash src/http_check.sh
+	@sudo TARGET=$(TARGET) DNS_SERVER=$(DNS_SERVER) bash src/dns_check.sh
+	@sudo TARGET="$(TARGET)" bash src/http_check.sh
 	@echo "[run] evidencia generada (ver archivos en $(OUT_DIR)/)"
 
 test: tools ## Ejecuta pruebas Bats; deja evidencia .tap
@@ -105,8 +105,4 @@ status-monitor-tls: ## State systemd del servicio de monitoreo TLS
 logs-monitor-tls: ## Verificacion TLS con logs con journalctl
 	@sudo journalctl -u $(SERVICE) -f
 
-OBJETIVO ?=google.com
-SERVIDOR ?=8.8.8.8
-.PHONY: run-bash
-run-bash: clean
-	@ sudo TARGET=${OBJETIVO} DNS_SERVER=${SERVIDOR} bash src/dns_check.sh
+

--- a/tests/test_dns.bats
+++ b/tests/test_dns.bats
@@ -1,7 +1,27 @@
 #!/usr/bin/env bats
 
-@test_dns "dig devuelve una respuesta no vacía" {
+setup() { rm -rf out; }
+
+@test "DNS: dig devuelve respuesta no vacía" {
   run dig example.com
   [ "$status" -eq 0 ]
   [ -n "$output" ]
+}
+
+@test "DNS: existe registro A válido para example.com" {
+  env TARGET=example.com DNS_SERVER=8.8.8.8 ./src/dns_check.sh
+
+  [ -f "out/dns_check.txt" ]
+  [ -f "out/parseo_awk.txt" ]
+
+  run grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}$' out/parseo_awk.txt
+  [ "$status" -eq 0 ]
+
+  run grep -E "\tA\t" out/dns_check.txt
+  [ "$status" -eq 0 ]
+}
+
+@test "Robustez: falla con servidor DNS inválido" {
+  run env TARGET=example.com DNS_SERVER=203.0.113.1 ./src/dns_check.sh
+  [ "$status" -ne 0 ]
 }

--- a/tests/test_http.bats
+++ b/tests/test_http.bats
@@ -1,18 +1,22 @@
 #!/usr/bin/env bats
 
-setup() {
-  rm -rf out
+setup() { rm -rf out; }
+
+@test "HTTP: script genera archivo con encabezado" {
+  TARGET=github.com ./src/http_check.sh
+  [ -f "out/http_check.txt" ]
+  grep "HTTP CHECK (github.com)" out/http_check.txt
+  grep -E "^HTTP/" out/http_check.txt
 }
 
-@test "script genera archivo de salida con encabezado HTTP" {
-  TARGET=github.com ./src/http_check.sh
+@test "HTTP: devuelve código 200 para example.com" {
+  TARGET=example.com ./src/http_check.sh
+  run grep -E "^HTTP/.* 200\b" out/http_check.txt
+  [ "$status" -eq 0 ]
+}
 
-  # verificamos que el archivo se creó
-  [ -f "out/http_check.txt" ]
-
-  # verificamos que contiene el nombre del target
-  grep "HTTP CHECK (github.com)" out/http_check.txt
-
-  # verificamos que contiene una línea que empiece con HTTP/
-  grep -E "^HTTP/" out/http_check.txt
+@test "Robustez: falla con dominio inválido y limpia artefactos" {
+  run env TARGET=dominio.que-no-existe.invalid ./src/http_check.sh
+  [ "$status" -ne 0 ]
+  [ ! -f "out/http_check.txt" ]
 }


### PR DESCRIPTION
ampliar los test bats tets_http.bats y test_dns.bats con las siguientes funcionalidades:
 - HTTP: verificar código 200 en respuesta.
 - DNS: validar que se obtiene un A válido.
 
modificar el nombre de las variables objetivo y servidor